### PR TITLE
AG-16: Fix 'Not Found' error when accessing root

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from .url_text_extractor import extract
 
 app = FastAPI()
 
-templates = Jinja2Templates(directory="templates")
+templates = Jinja2Templates(directory="app/templates")
 
 @app.get("/")
 def read_root(request: Request):


### PR DESCRIPTION
This PR addresses the issue of receiving a 'Not Found' error when accessing the root of the application. The issue was due to the incorrect structure of the FastAPI application. The templates directory was not located inside the app/ directory, which is the expected structure for FastAPI applications. This PR moves the templates directory into the app/ directory and updates the references in the code accordingly.

### Test Plan

pytest