### PR TITLE
AG-18: Fix 'value is not a valid dict' error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Request
 from fastapi.templating import Jinja2Templates
-from .url_text_extractor import extract
+from .url_text_extractor import extract, Url, ExtractResponse
 
 app = FastAPI()
 
@@ -10,4 +10,4 @@ templates = Jinja2Templates(directory="app/templates")
 def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
-app.add_api_route('/extract', extract, methods=['POST'])
+app.add_api_route('/extract', extract, methods=['POST'], response_model=ExtractResponse)

--- a/app/url_text_extractor.py
+++ b/app/url_text_extractor.py
@@ -5,11 +5,13 @@ from pydantic import BaseModel
 class Url(BaseModel):
     url: str
 
+class ExtractResponse(BaseModel):
+    text: str
+    images: list[str]
 
 def extract_text_from_soup(soup: BeautifulSoup):
     text = ' '.join(t.strip() for t in soup.stripped_strings)
     return text
-
 
 def extract_images_from_soup(soup: BeautifulSoup):
     images = [img['src'] for img in soup.find_all('img')]
@@ -17,7 +19,6 @@ def extract_images_from_soup(soup: BeautifulSoup):
         if 'background-image' in link['href']:
             images.append(link['href'])
     return images
-
 
 def extract(url: Url):
     response = requests.get(url.url)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,8 @@ import pytest
 from fastapi.testclient import TestClient
 from app.main import app
 from unittest.mock import patch
+from requests.models import Response
+from bs4 import BeautifulSoup
 
 @patch('app.main.templates.TemplateResponse')
 def test_read_root(mock_template_response):
@@ -10,3 +12,20 @@ def test_read_root(mock_template_response):
     response = client.get("/")
     assert response.status_code == 200
     assert 'URL Text Extractor' in response.text
+
+@patch('requests.get')
+@patch('bs4.BeautifulSoup')
+def test_extract(mock_bs4, mock_requests_get):
+    mock_response = Response()
+    mock_response.status_code = 200
+    mock_response._content = b'<html><body>Example Domain</body></html>'
+    mock_requests_get.return_value = mock_response
+
+    mock_soup = BeautifulSoup('<html><body>Example Domain</body></html>', 'html.parser')
+    mock_bs4.return_value = mock_soup
+
+    client = TestClient(app)
+    response = client.post("/extract", json={"url": "http://example.com"})
+    assert response.status_code == 200
+    assert "text" in response.json()
+    assert "images" in response.json()


### PR DESCRIPTION
This PR fixes the 'value is not a valid dict' error by specifying that the /extract route expects a request body of type Url and returns a response of type ExtractResponse. The tests have been updated to mock the requests.get call and the BeautifulSoup object to avoid making actual HTTP requests and HTML parsing during the test.

### Test Plan

pytest