### PR TITLE
AG-18: Fix 'value is not a valid dict' error

### DIFF
--- a/app/url_text_extractor.py
+++ b/app/url_text_extractor.py
@@ -5,11 +5,9 @@ from pydantic import BaseModel
 class Url(BaseModel):
     url: str
 
-
 def extract_text_from_soup(soup: BeautifulSoup):
     text = ' '.join(t.strip() for t in soup.stripped_strings)
     return text
-
 
 def extract_images_from_soup(soup: BeautifulSoup):
     images = [img['src'] for img in soup.find_all('img')]
@@ -18,8 +16,8 @@ def extract_images_from_soup(soup: BeautifulSoup):
             images.append(link['href'])
     return images
 
-
-def extract(url: Url):
+def extract(url: dict):
+    url = Url(**url)
     response = requests.get(url.url)
     soup = BeautifulSoup(response.text, 'html.parser')
     text = extract_text_from_soup(soup)

--- a/tests/test_url_text_extractor.py
+++ b/tests/test_url_text_extractor.py
@@ -1,14 +1,26 @@
 import pytest
 from bs4 import BeautifulSoup
-from app.url_text_extractor import extract_text_from_soup, extract_images_from_soup
+from app.url_text_extractor import extract_text_from_soup, extract_images_from_soup, extract, Url
 from unittest.mock import patch
-
+import requests
 
 def test_extract_text_from_soup():
     soup = BeautifulSoup('<html><body>Example Domain</body></html>', 'html.parser')
     assert extract_text_from_soup(soup) == 'Example Domain'
 
-
 def test_extract_images_from_soup():
     soup = BeautifulSoup('<html><body><img src="example.jpg"></body></html>', 'html.parser')
     assert extract_images_from_soup(soup) == ['example.jpg']
+
+@patch('requests.get')
+def test_extract(mock_get):
+    mock_response = requests.Response()
+    mock_response.status_code = 200
+    mock_response._content = b'<html><body>Example Domain <img src="example.jpg"></body></html>'
+    mock_get.return_value = mock_response
+
+    url = {'url': 'http://example.com'}
+    result = extract(url)
+    assert isinstance(result, dict)
+    assert 'text' in result and 'Example Domain' in result['text']
+    assert 'images' in result and result['images'] == ['example.jpg']


### PR DESCRIPTION
This PR fixes the error that occurs when the 'Extract' button is clicked. The 'extract' function in 'url_text_extractor.py' was expecting a 'Url' object, but it was receiving a different data type. The function has been modified to accept a dictionary and then convert it to a 'Url' object. The tests have also been updated to reflect this change.

### Test Plan

pytest