### PR TITLE
AG-18: Fix 'value is not a valid dict' error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Depends
 from fastapi.templating import Jinja2Templates
-from .url_text_extractor import extract
+from .url_text_extractor import extract, Url
 
 app = FastAPI()
 
@@ -10,4 +10,4 @@ templates = Jinja2Templates(directory="app/templates")
 def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
-app.add_api_route('/extract', extract, methods=['POST'])
+app.add_api_route('/extract', extract, methods=['POST'], dependencies=[Depends(Url)])

--- a/app/url_text_extractor.py
+++ b/app/url_text_extractor.py
@@ -1,6 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 from pydantic import BaseModel
+from fastapi import Depends
 
 class Url(BaseModel):
     url: str
@@ -19,7 +20,7 @@ def extract_images_from_soup(soup: BeautifulSoup):
     return images
 
 
-def extract(url: Url):
+def extract(url: Url = Depends()):
     response = requests.get(url.url)
     soup = BeautifulSoup(response.text, 'html.parser')
     text = extract_text_from_soup(soup)

--- a/tests/test_url_text_extractor.py
+++ b/tests/test_url_text_extractor.py
@@ -1,7 +1,7 @@
 import pytest
 from bs4 import BeautifulSoup
-from app.url_text_extractor import extract_text_from_soup, extract_images_from_soup
-from unittest.mock import patch
+from app.url_text_extractor import extract_text_from_soup, extract_images_from_soup, extract, Url
+from unittest.mock import patch, Mock
 
 
 def test_extract_text_from_soup():
@@ -12,3 +12,16 @@ def test_extract_text_from_soup():
 def test_extract_images_from_soup():
     soup = BeautifulSoup('<html><body><img src="example.jpg"></body></html>', 'html.parser')
     assert extract_images_from_soup(soup) == ['example.jpg']
+
+@patch('app.url_text_extractor.requests.get')
+def test_extract(mock_get):
+    mock_response = Mock()
+    mock_response.text = '<html><body>Example Domain <img src="example.jpg"></body></html>'
+    mock_get.return_value = mock_response
+
+    url = Url(url='http://example.com')
+    result = extract(url)
+    assert 'text' in result
+    assert 'images' in result
+    assert result['text'] == 'Example Domain'
+    assert result['images'] == ['example.jpg']


### PR DESCRIPTION
This PR resolves the issue described in the Jira ticket AG-18. The issue was caused by incorrect parsing of the incoming JSON data from the POST request in the `extract` function. The `Url` model is now used to validate the incoming data as a dictionary. The endpoint in `app/main.py` has been adjusted to properly parse the incoming JSON request body using FastAPI's dependency injection system, ensuring that the `Url` model is correctly utilized to validate and extract the URL from the request. The tests have been updated to correctly import the `extract` function and to mock the HTTP request made within the function.

### Test Plan

pytest