### PR TITLE
AG-22: Fix deploy issue - ModuleNotFoundError: No module named 'app'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM --platform=linux/amd64 tiangolo/uvicorn-gunicorn-fastapi:python3.7
 
 WORKDIR /app
 
-COPY ./app /app
-
-COPY requirements.txt /app/requirements.txt
+COPY . /app
 
 RUN pip install -r requirements.txt
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This PR addresses the deployment issue where the application fails to start due to a `ModuleNotFoundError: No module named 'app'`. The Dockerfile has been updated to copy the entire current directory into the `/app` directory of the container, ensuring that all necessary Python modules, including the `app` module, are available in the Docker environment. The command in the Dockerfile has also been updated to correctly reference the FastAPI application instance for Uvicorn to run.

### Test Plan

pytest